### PR TITLE
Update example to correctly become sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The simplest configuration therefore consists of:
 ---
 - name: Simple Example
   hosts: localhost
+  become: yes
   roles:
     - { role: elasticsearch, es_instance_name: "node1" }
   vars:


### PR DESCRIPTION
I tried to run the examples from the README in an Ubuntu 14.04 Vagrant box and got the following error:

```
'/bin/sh -c '"'"'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python /home/vagrant/.ansible/tmp/ansible-tmp-1476469808.12-176752272225303/apt; rm -rf "/home/vagrant/.ansible/tmp/ansible-tmp-1476469808.12-176752272225303/" > /dev/null 2>&1 && sleep 0'"'"''
fatal: [elasticsearch_configure_cluster_role_server]: FAILED! => {"changed": false, "failed": true, "invocation": {"module_args": {"allow_unauthenticated": false, "autoremove": false, "cache_valid_time": null, "deb": null, "default_release": null, "dpkg_options": "force-confdef,force-confold", "force": true, "install_recommends": null, "name": "openjdk-7-jre-headless", "only_upgrade": false, "package": ["openjdk-7-jre-headless"], "purge": false, "state": "present", "update_cache": true, "upgrade": null}, "module_name": "apt"}, "msg": "Failed to lock apt for exclusive operation"}
```

It appears that you need to become sudo in order to run any `apt` commands on the system. The example works after the proposed change. Please let me know if I missed something and/or ran it incorrectly.
